### PR TITLE
Add STL mesh pipeline and multithreaded smoothing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Build artefacts from the C++ prototype
+path_gradient
+mesh_processor

--- a/README.md
+++ b/README.md
@@ -12,6 +12,40 @@ Check out my [YouTube video](https://youtu.be/M51bMMVWbC8?si=pfud7bHgjYDnO2_z) f
 Thank you to JLCCNC for helping create the extruder mount and build plate for my [4 Axis Core R-Theta Printer](https://github.com/jyjblrd/Core-R-Theta-4-Axis-Printer).
 
 
+## Native C++ mesh processing toolkit
+
+The original slicer prototype is implemented in Python within `main.ipynb`. For workloads that are
+dominated by the `calculate_path_length_to_base_gradient` routine we now ship a standalone, optimised
+C++ rewrite in [`cpp/rotation_optimizer.cpp`](cpp/rotation_optimizer.cpp). The implementation keeps the
+same inputs as the notebook version (cell centres, neighbourhood lists, face normals, etc.) and performs
+multi-source Dijkstra, plane fitting and optional multi-threaded smoothing using cache-friendly data
+structures.
+
+Two small utilities demonstrate how to embed the native routines:
+
+* [`cpp/example.cpp`](cpp/example.cpp) keeps the original, in-memory smoke test which can be compiled with:
+
+  ```bash
+  g++ -std=c++17 -O3 cpp/rotation_optimizer.cpp cpp/example.cpp -o path_gradient
+  ./path_gradient
+  ```
+
+* [`cpp/mesh_processor.cpp`](cpp/mesh_processor.cpp) loads an arbitrary STL mesh, constructs the required
+  connectivity on the fly and exports both a cleaned STL and a coloured PLY heat-map visualisation of the
+  gradient. The build requires the STL utilities in [`cpp/stl_mesh.cpp`](cpp/stl_mesh.cpp):
+
+  ```bash
+  g++ -std=c++17 -O3 -pthread cpp/mesh_processor.cpp cpp/stl_mesh.cpp cpp/rotation_optimizer.cpp -o mesh_processor
+  ./mesh_processor input.stl processed.stl gradient.ply
+  ```
+
+  The optional final argument specifies the maximum overhang angle in degrees (defaults to 30°). The
+  generated PLY can be inspected in MeshLab, Blender or any viewer that supports vertex colours.
+
+Both binaries are ignored by git and may be safely rebuilt locally whenever the underlying algorithms
+change.
+
+
 
 Bibtex Citation:
 ```

--- a/cpp/example.cpp
+++ b/cpp/example.cpp
@@ -1,0 +1,65 @@
+#include "rotation_optimizer.hpp"
+
+#include <iomanip>
+#include <iostream>
+
+int main() {
+    s4::PathGradientInput input;
+    input.cell_centers = {
+        {0.0, 0.0, 0.0},
+        {1.0, 0.0, 1.0},
+        {0.0, 1.0, 1.2},
+        {-1.0, 0.0, 1.1},
+        {0.0, -1.0, 0.9},
+    };
+
+    input.face_normals = {
+        {0.0, 0.0, 1.0},
+        {0.0, 0.0, -1.0},
+        {0.1, 0.0, -0.99},
+        {-0.1, 0.0, -0.99},
+        {0.0, 0.2, -0.98},
+    };
+
+    input.point_neighbors = {
+        {1, 2, 3, 4},
+        {0, 2, 4},
+        {0, 1, 3},
+        {0, 2, 4},
+        {0, 1, 3},
+    };
+
+    input.edge_neighbors = {
+        {1, 2, 3, 4},
+        {0, 2, 3, 4},
+        {0, 1, 3},
+        {0, 1, 2, 4},
+        {0, 1, 3},
+    };
+
+    input.bottom_cells = {0};
+    input.max_overhang_degrees = 30.0;
+    input.initial_rotation_field_smoothing = 2;
+    input.set_initial_rotation_to_zero = false;
+
+    const s4::PathGradientResult result = s4::compute_path_length_to_base_gradient(input);
+
+    std::cout << std::fixed << std::setprecision(6);
+    std::cout << "Cell gradients:\n";
+    for (std::size_t i = 0; i < result.gradient.size(); ++i) {
+        std::cout << "  " << i << ": " << result.gradient[i] << '\n';
+    }
+
+    std::cout << "\nDistances to bottom:\n";
+    for (std::size_t i = 0; i < result.distance_to_bottom.size(); ++i) {
+        std::cout << "  " << i << ": " << result.distance_to_bottom[i] << '\n';
+    }
+
+    std::cout << "\nClosest bottom indices:\n";
+    for (std::size_t i = 0; i < result.closest_bottom_index.size(); ++i) {
+        std::cout << "  " << i << ": " << result.closest_bottom_index[i] << '\n';
+    }
+
+    return 0;
+}
+

--- a/cpp/mesh_processor.cpp
+++ b/cpp/mesh_processor.cpp
@@ -1,0 +1,65 @@
+#include "rotation_optimizer.hpp"
+#include "stl_mesh.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <exception>
+#include <iomanip>
+#include <iostream>
+#include <string>
+
+namespace {
+
+void print_usage(const char* executable) {
+    std::cerr << "Usage: " << executable
+              << " <input.stl> <output.stl> <visualisation.ply> [overhang_degrees]" << std::endl;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc < 4) {
+        print_usage(argv[0]);
+        return 1;
+    }
+
+    const std::string input_path = argv[1];
+    const std::string output_stl_path = argv[2];
+    const std::string output_ply_path = argv[3];
+    double overhang_degrees = 30.0;
+    if (argc >= 5) {
+        overhang_degrees = std::stod(argv[4]);
+    }
+
+    try {
+        const s4::TriangleMesh mesh = s4::load_stl(input_path);
+        const s4::PathGradientInput gradient_input =
+            s4::build_path_gradient_input(mesh, 0.02, overhang_degrees, 3);
+        const s4::PathGradientResult result = s4::compute_path_length_to_base_gradient(gradient_input);
+
+        s4::write_binary_stl(mesh, output_stl_path);
+        s4::write_colored_ply(mesh, result.gradient, output_ply_path);
+
+        std::cout << "Processed mesh with " << mesh.faces.size() << " triangles and "
+                  << mesh.vertices.size() << " unique vertices." << std::endl;
+        std::size_t reachable = 0;
+        double max_distance = 0.0;
+        for (double value : result.distance_to_bottom) {
+            if (std::isfinite(value)) {
+                ++reachable;
+                max_distance = std::max(max_distance, value);
+            }
+        }
+        std::cout << "Reachable faces: " << reachable << "/" << mesh.faces.size()
+                  << ", max distance: " << std::fixed << std::setprecision(3) << max_distance << " units"
+                  << std::endl;
+        std::cout << "Visualisation written to " << output_ply_path << std::endl;
+        std::cout << "Binary STL written to " << output_stl_path << std::endl;
+    } catch (const std::exception& error) {
+        std::cerr << "Error: " << error.what() << std::endl;
+        return 1;
+    }
+
+    return 0;
+}
+

--- a/cpp/rotation_optimizer.cpp
+++ b/cpp/rotation_optimizer.cpp
@@ -1,0 +1,391 @@
+#include "rotation_optimizer.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <numeric>
+#include <queue>
+#include <thread>
+#include <utility>
+
+namespace s4 {
+namespace {
+
+constexpr double kPi = 3.14159265358979323846;
+
+template <typename Func>
+void parallel_for(std::size_t count, Func&& func) {
+    if (count == 0) {
+        return;
+    }
+    const std::size_t hardware_threads = std::max<std::size_t>(1, std::thread::hardware_concurrency());
+    const std::size_t chunk = (count + hardware_threads - 1) / hardware_threads;
+    std::vector<std::thread> workers;
+    workers.reserve(hardware_threads);
+    for (std::size_t index = 0; index < hardware_threads; ++index) {
+        const std::size_t start = index * chunk;
+        if (start >= count) {
+            break;
+        }
+        const std::size_t end = std::min(count, start + chunk);
+        workers.emplace_back([start, end, &func]() {
+            for (std::size_t i = start; i < end; ++i) {
+                func(i);
+            }
+        });
+    }
+    for (auto& worker : workers) {
+        worker.join();
+    }
+}
+
+struct QueueEntry {
+    double distance;
+    int node;
+    int bottom;
+};
+
+inline double clamp(double value, double min_value, double max_value) {
+    if (value < min_value) {
+        return min_value;
+    }
+    if (value > max_value) {
+        return max_value;
+    }
+    return value;
+}
+
+std::array<double, 2> xy_components(const std::array<double, 3>& value) {
+    return {value[0], value[1]};
+}
+
+double euclidean_distance(const std::array<double, 3>& a, const std::array<double, 3>& b) {
+    const double dx = a[0] - b[0];
+    const double dy = a[1] - b[1];
+    const double dz = a[2] - b[2];
+    return std::sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+double norm2d(const std::array<double, 2>& v) {
+    return std::hypot(v[0], v[1]);
+}
+
+std::array<double, 2> normalize2d(const std::array<double, 2>& v) {
+    const double n = norm2d(v);
+    if (n <= 1e-12) {
+        return {0.0, 0.0};
+    }
+    return {v[0] / n, v[1] / n};
+}
+
+std::array<double, 3> normalize3d(const std::array<double, 3>& v) {
+    const double n = std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+    if (n <= 1e-12) {
+        return {0.0, 0.0, 0.0};
+    }
+    return {v[0] / n, v[1] / n, v[2] / n};
+}
+
+double dot2d(const std::array<double, 2>& a, const std::array<double, 2>& b) {
+    return a[0] * b[0] + a[1] * b[1];
+}
+
+struct PlaneParameters {
+    double a;
+    double b;
+    double c;
+    bool valid;
+};
+
+PlaneParameters fit_plane(const std::vector<int>& indices,
+                          const std::vector<std::array<double, 3>>& cell_centers,
+                          const std::vector<double>& distances) {
+    const std::size_t count = indices.size();
+    if (count < 3) {
+        return {0.0, 0.0, 0.0, false};
+    }
+
+    double sum_x = 0.0;
+    double sum_y = 0.0;
+    double sum_z = 0.0;
+    double sum_xx = 0.0;
+    double sum_xy = 0.0;
+    double sum_yy = 0.0;
+    double sum_xz = 0.0;
+    double sum_yz = 0.0;
+
+    for (const int index : indices) {
+        const double x = cell_centers[index][0];
+        const double y = cell_centers[index][1];
+        const double z = distances[index];
+
+        sum_x += x;
+        sum_y += y;
+        sum_z += z;
+        sum_xx += x * x;
+        sum_xy += x * y;
+        sum_yy += y * y;
+        sum_xz += x * z;
+        sum_yz += y * z;
+    }
+
+    double matrix[3][4] = {
+        {sum_xx, sum_xy, sum_x, sum_xz},
+        {sum_xy, sum_yy, sum_y, sum_yz},
+        {sum_x, sum_y, static_cast<double>(count), sum_z},
+    };
+
+    for (int pivot = 0; pivot < 3; ++pivot) {
+        int best_row = pivot;
+        for (int row = pivot + 1; row < 3; ++row) {
+            if (std::fabs(matrix[row][pivot]) > std::fabs(matrix[best_row][pivot])) {
+                best_row = row;
+            }
+        }
+        if (std::fabs(matrix[best_row][pivot]) <= 1e-12) {
+            return {0.0, 0.0, 0.0, false};
+        }
+        if (best_row != pivot) {
+            for (int col = pivot; col < 4; ++col) {
+                std::swap(matrix[pivot][col], matrix[best_row][col]);
+            }
+        }
+
+        const double pivot_value = matrix[pivot][pivot];
+        for (int col = pivot; col < 4; ++col) {
+            matrix[pivot][col] /= pivot_value;
+        }
+        for (int row = 0; row < 3; ++row) {
+            if (row == pivot) {
+                continue;
+            }
+            const double factor = matrix[row][pivot];
+            for (int col = pivot; col < 4; ++col) {
+                matrix[row][col] -= factor * matrix[pivot][col];
+            }
+        }
+    }
+
+    const double a = matrix[0][3];
+    const double b = matrix[1][3];
+    const double c = matrix[2][3];
+    if (!std::isfinite(a) || !std::isfinite(b) || !std::isfinite(c)) {
+        return {0.0, 0.0, 0.0, false};
+    }
+    return {a, b, c, true};
+}
+
+struct DijkstraResult {
+    std::vector<double> distance;
+    std::vector<int> closest_bottom;
+};
+
+DijkstraResult multi_source_dijkstra(const PathGradientInput& input) {
+    const std::size_t count = input.cell_centers.size();
+    DijkstraResult result;
+    result.distance.assign(count, std::numeric_limits<double>::infinity());
+    result.closest_bottom.assign(count, -1);
+
+    auto cmp = [](const QueueEntry& lhs, const QueueEntry& rhs) {
+        return lhs.distance > rhs.distance;
+    };
+    std::priority_queue<QueueEntry, std::vector<QueueEntry>, decltype(cmp)> queue(cmp);
+
+    for (int bottom : input.bottom_cells) {
+        if (bottom < 0 || static_cast<std::size_t>(bottom) >= count) {
+            continue;
+        }
+        result.distance[bottom] = 0.0;
+        result.closest_bottom[bottom] = bottom;
+        queue.push({0.0, bottom, bottom});
+    }
+
+    while (!queue.empty()) {
+        const QueueEntry entry = queue.top();
+        queue.pop();
+        if (entry.distance > result.distance[entry.node] + 1e-12) {
+            continue;
+        }
+        const auto& neighbours = input.point_neighbors[entry.node];
+        for (int neighbour : neighbours) {
+            if (neighbour < 0 || static_cast<std::size_t>(neighbour) >= count) {
+                continue;
+            }
+            const double weight = euclidean_distance(input.cell_centers[entry.node],
+                                                     input.cell_centers[neighbour]);
+            const double candidate = entry.distance + weight;
+            if (candidate + 1e-12 < result.distance[neighbour]) {
+                result.distance[neighbour] = candidate;
+                result.closest_bottom[neighbour] = entry.bottom;
+                queue.push({candidate, neighbour, entry.bottom});
+            }
+        }
+    }
+
+    return result;
+}
+
+std::vector<int> build_bottom_mask(const std::vector<int>& bottom_cells, std::size_t count) {
+    std::vector<int> mask(count, 0);
+    for (int bottom : bottom_cells) {
+        if (bottom >= 0 && static_cast<std::size_t>(bottom) < count) {
+            mask[bottom] = 1;
+        }
+    }
+    return mask;
+}
+
+std::vector<int> unique_indices(std::vector<int> values) {
+    std::sort(values.begin(), values.end());
+    values.erase(std::unique(values.begin(), values.end()), values.end());
+    return values;
+}
+
+}  // namespace
+
+PathGradientResult compute_path_length_to_base_gradient(const PathGradientInput& input) {
+    PathGradientResult output;
+    const std::size_t count = input.cell_centers.size();
+    output.gradient.assign(count, 0.0);
+    output.distance_to_bottom.assign(count, std::numeric_limits<double>::quiet_NaN());
+    output.closest_bottom_index.assign(count, -1);
+
+    if (count == 0) {
+        return output;
+    }
+
+    const auto bottom_mask = build_bottom_mask(input.bottom_cells, count);
+    const DijkstraResult dijkstra_result = multi_source_dijkstra(input);
+
+    const double max_overhang_radians = (input.max_overhang_degrees + 90.0) * kPi / 180.0;
+
+    for (std::size_t index = 0; index < count; ++index) {
+        const double dot_with_up = input.face_normals[index][2];
+        const double angle_cosine = clamp(dot_with_up, -1.0, 1.0);
+        const double angle = std::acos(angle_cosine);
+        const bool is_overhang = angle > max_overhang_radians;
+        if (is_overhang && !bottom_mask[index] && dijkstra_result.closest_bottom[index] != -1) {
+            output.distance_to_bottom[index] = dijkstra_result.distance[index];
+            output.closest_bottom_index[index] = dijkstra_result.closest_bottom[index];
+        }
+    }
+
+    for (std::size_t index = 0; index < count; ++index) {
+        if (!std::isfinite(output.distance_to_bottom[index])) {
+            continue;
+        }
+
+        std::vector<int> local_cells = input.edge_neighbors[index];
+        local_cells.push_back(static_cast<int>(index));
+        local_cells = unique_indices(std::move(local_cells));
+
+        std::vector<int> valid_cells;
+        valid_cells.reserve(local_cells.size());
+        for (int cell : local_cells) {
+            if (cell >= 0 && static_cast<std::size_t>(cell) < count &&
+                std::isfinite(output.distance_to_bottom[cell])) {
+                valid_cells.push_back(cell);
+            }
+        }
+
+        if (valid_cells.size() < 3) {
+            const int closest_bottom = output.closest_bottom_index[index];
+            if (closest_bottom < 0 || static_cast<std::size_t>(closest_bottom) >= count) {
+                continue;
+            }
+            const auto location_to_roll_to = xy_components(input.cell_centers[closest_bottom]);
+            auto direction_to_bottom = normalize2d({location_to_roll_to[0] - input.cell_centers[index][0],
+                                                    location_to_roll_to[1] - input.cell_centers[index][1]});
+            auto cell_center = normalize2d(xy_components(input.cell_centers[index]));
+            const double dot_value = dot2d(cell_center, direction_to_bottom);
+            if (std::fabs(dot_value) <= 1e-12 || std::isnan(dot_value)) {
+                output.gradient[index] = 0.0;
+            } else {
+                output.gradient[index] = dot_value / std::fabs(dot_value);
+            }
+            continue;
+        }
+
+        const PlaneParameters plane = fit_plane(valid_cells, input.cell_centers, output.distance_to_bottom);
+        if (!plane.valid) {
+            double sum = 0.0;
+            int count_valid = 0;
+            for (int cell : valid_cells) {
+                const double value = output.gradient[cell];
+                if (!std::isnan(value)) {
+                    sum += value;
+                    ++count_valid;
+                }
+            }
+            output.gradient[index] = (count_valid > 0) ? sum / count_valid : 0.0;
+            continue;
+        }
+
+        const auto plane_normal = normalize3d({plane.a, plane.b, -1.0});
+        const auto cell_center_direction = normalize2d(xy_components(input.cell_centers[index]));
+        const double gradient_value = dot2d(cell_center_direction, {plane_normal[0], plane_normal[1]});
+        if (std::isnan(gradient_value)) {
+            double sum = 0.0;
+            int count_valid = 0;
+            for (int cell : valid_cells) {
+                const double value = output.gradient[cell];
+                if (!std::isnan(value)) {
+                    sum += value;
+                    ++count_valid;
+                }
+            }
+            output.gradient[index] = (count_valid > 0) ? sum / count_valid : 0.0;
+        } else {
+            output.gradient[index] = gradient_value;
+        }
+    }
+
+    if (input.initial_rotation_field_smoothing > 0) {
+        std::vector<double> smoothed(count, 0.0);
+        for (int iteration = 0; iteration < input.initial_rotation_field_smoothing; ++iteration) {
+            std::fill(smoothed.begin(), smoothed.end(), 0.0);
+            parallel_for(count, [&](std::size_t index) {
+                const double value = output.gradient[index];
+                if (value == 0.0 || std::isnan(value)) {
+                    smoothed[index] = value;
+                    return;
+                }
+                std::vector<int> local_cells = input.point_neighbors[index];
+                for (int neighbour : input.point_neighbors[index]) {
+                    const auto& neighbour_neighbours = input.point_neighbors[neighbour];
+                    local_cells.insert(local_cells.end(), neighbour_neighbours.begin(), neighbour_neighbours.end());
+                }
+                local_cells.push_back(static_cast<int>(index));
+                local_cells = unique_indices(std::move(local_cells));
+
+                double sum = 0.0;
+                int count_valid = 0;
+                for (int cell : local_cells) {
+                    if (cell < 0 || static_cast<std::size_t>(cell) >= count) {
+                        continue;
+                    }
+                    const double neighbour_value = output.gradient[cell];
+                    if (neighbour_value != 0.0 && !std::isnan(neighbour_value)) {
+                        sum += neighbour_value;
+                        ++count_valid;
+                    }
+                }
+                smoothed[index] = (count_valid > 0) ? sum / count_valid : value;
+            });
+            output.gradient = smoothed;
+        }
+    }
+
+    if (!input.set_initial_rotation_to_zero) {
+        for (double& value : output.gradient) {
+            if (std::fabs(value) <= 1e-12) {
+                value = std::numeric_limits<double>::quiet_NaN();
+            }
+        }
+    }
+
+    return output;
+}
+
+}  // namespace s4
+

--- a/cpp/rotation_optimizer.hpp
+++ b/cpp/rotation_optimizer.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <vector>
+
+namespace s4 {
+
+struct PathGradientInput {
+    std::vector<std::array<double, 3>> cell_centers;
+    std::vector<std::array<double, 3>> face_normals;
+    std::vector<std::vector<int>> point_neighbors;
+    std::vector<std::vector<int>> edge_neighbors;
+    std::vector<int> bottom_cells;
+    double max_overhang_degrees = 0.0;
+    int initial_rotation_field_smoothing = 0;
+    bool set_initial_rotation_to_zero = true;
+};
+
+struct PathGradientResult {
+    std::vector<double> gradient;
+    std::vector<double> distance_to_bottom;
+    std::vector<int> closest_bottom_index;
+};
+
+PathGradientResult compute_path_length_to_base_gradient(const PathGradientInput& input);
+
+}  // namespace s4
+

--- a/cpp/stl_mesh.cpp
+++ b/cpp/stl_mesh.cpp
@@ -1,0 +1,452 @@
+#include "stl_mesh.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <iterator>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+namespace s4 {
+namespace {
+
+struct VertexKey {
+    long long x;
+    long long y;
+    long long z;
+
+    bool operator==(const VertexKey& other) const {
+        return x == other.x && y == other.y && z == other.z;
+    }
+};
+
+struct VertexKeyHash {
+    std::size_t operator()(const VertexKey& key) const noexcept {
+        const std::size_t hx = std::hash<long long>{}(key.x);
+        const std::size_t hy = std::hash<long long>{}(key.y);
+        const std::size_t hz = std::hash<long long>{}(key.z);
+        return hx ^ (hy << 1) ^ (hz << 2);
+    }
+};
+
+VertexKey make_key(const std::array<double, 3>& vertex) {
+    constexpr double kScale = 1'000'000.0;  // micrometre precision
+    return {static_cast<long long>(std::llround(vertex[0] * kScale)),
+            static_cast<long long>(std::llround(vertex[1] * kScale)),
+            static_cast<long long>(std::llround(vertex[2] * kScale))};
+}
+
+std::array<double, 3> compute_face_normal(const std::array<double, 3>& a,
+                                          const std::array<double, 3>& b,
+                                          const std::array<double, 3>& c) {
+    const double ux = b[0] - a[0];
+    const double uy = b[1] - a[1];
+    const double uz = b[2] - a[2];
+    const double vx = c[0] - a[0];
+    const double vy = c[1] - a[1];
+    const double vz = c[2] - a[2];
+
+    std::array<double, 3> normal = {
+        uy * vz - uz * vy,
+        uz * vx - ux * vz,
+        ux * vy - uy * vx,
+    };
+
+    const double length = std::sqrt(normal[0] * normal[0] + normal[1] * normal[1] +
+                                    normal[2] * normal[2]);
+    if (length <= 1e-12) {
+        return {0.0, 0.0, 0.0};
+    }
+    normal[0] /= length;
+    normal[1] /= length;
+    normal[2] /= length;
+    return normal;
+}
+
+std::array<double, 3> compute_centroid(const std::array<double, 3>& a,
+                                       const std::array<double, 3>& b,
+                                       const std::array<double, 3>& c) {
+    return {(a[0] + b[0] + c[0]) / 3.0,
+            (a[1] + b[1] + c[1]) / 3.0,
+            (a[2] + b[2] + c[2]) / 3.0};
+}
+
+TriangleMesh mesh_from_raw_faces(
+    const std::vector<std::array<double, 3>>& raw_vertices,
+    const std::vector<std::array<double, 3>>& raw_normals) {
+    TriangleMesh mesh;
+    std::unordered_map<VertexKey, int, VertexKeyHash> vertex_map;
+    mesh.vertices.reserve(raw_vertices.size());
+    mesh.faces.reserve(raw_vertices.size() / 3);
+    mesh.face_normals.reserve(raw_vertices.size() / 3);
+    mesh.face_centroids.reserve(raw_vertices.size() / 3);
+
+    for (std::size_t i = 0; i + 2 < raw_vertices.size(); i += 3) {
+        const auto& a = raw_vertices[i];
+        const auto& b = raw_vertices[i + 1];
+        const auto& c = raw_vertices[i + 2];
+        std::array<int, 3> face{};
+        const std::array<std::array<double, 3>, 3> verts = {a, b, c};
+        for (int v = 0; v < 3; ++v) {
+            const VertexKey key = make_key(verts[v]);
+            auto it = vertex_map.find(key);
+            if (it == vertex_map.end()) {
+                const int index = static_cast<int>(mesh.vertices.size());
+                vertex_map.emplace(key, index);
+                mesh.vertices.push_back(verts[v]);
+                face[v] = index;
+            } else {
+                face[v] = it->second;
+            }
+        }
+        mesh.faces.push_back(face);
+
+        std::array<double, 3> normal = raw_normals[i / 3];
+        const double length = std::sqrt(normal[0] * normal[0] + normal[1] * normal[1] +
+                                        normal[2] * normal[2]);
+        if (length <= 1e-6) {
+            normal = compute_face_normal(a, b, c);
+        } else {
+            normal[0] /= length;
+            normal[1] /= length;
+            normal[2] /= length;
+        }
+        mesh.face_normals.push_back(normal);
+        mesh.face_centroids.push_back(compute_centroid(a, b, c));
+    }
+
+    return mesh;
+}
+
+bool looks_like_ascii(const std::vector<char>& buffer) {
+    const std::string header(buffer.begin(), buffer.begin() + std::min<std::size_t>(buffer.size(), 80));
+    if (header.rfind("solid", 0) != 0) {
+        return false;
+    }
+    for (char c : buffer) {
+        if (c == '\0') {
+            return false;
+        }
+    }
+    return true;
+}
+
+TriangleMesh load_binary_stl(const std::vector<char>& buffer) {
+    if (buffer.size() < 84) {
+        throw std::runtime_error("STL file too small to contain header");
+    }
+    std::uint32_t triangle_count = 0;
+    std::memcpy(&triangle_count, buffer.data() + 80, sizeof(std::uint32_t));
+    const std::size_t expected_size = 84 + static_cast<std::size_t>(triangle_count) * 50;
+    if (expected_size > buffer.size()) {
+        throw std::runtime_error("Binary STL reports more triangles than bytes in file");
+    }
+
+    std::vector<std::array<double, 3>> vertices;
+    std::vector<std::array<double, 3>> normals;
+    vertices.reserve(triangle_count * 3);
+    normals.reserve(triangle_count);
+
+    std::size_t offset = 84;
+    for (std::uint32_t i = 0; i < triangle_count; ++i) {
+        std::array<float, 12> record{};
+        std::memcpy(record.data(), buffer.data() + offset, sizeof(float) * 12);
+        offset += 48;
+        offset += 2;  // attribute byte count
+
+        std::array<double, 3> normal = {record[0], record[1], record[2]};
+        normals.push_back({normal[0], normal[1], normal[2]});
+        for (int v = 0; v < 3; ++v) {
+            vertices.push_back({record[3 + v * 3], record[4 + v * 3], record[5 + v * 3]});
+        }
+    }
+    return mesh_from_raw_faces(vertices, normals);
+}
+
+TriangleMesh load_ascii_stl(const std::vector<char>& buffer) {
+    std::string text(buffer.begin(), buffer.end());
+    std::istringstream stream(text);
+    std::string token;
+    std::vector<std::array<double, 3>> vertices;
+    std::vector<std::array<double, 3>> normals;
+
+    std::array<double, 3> current_normal = {0.0, 0.0, 0.0};
+    while (stream >> token) {
+        for (char& c : token) {
+            c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+        }
+        if (token == "facet") {
+            std::string normal_token;
+            stream >> normal_token;
+            if (normal_token != "normal") {
+                throw std::runtime_error("Malformed ASCII STL: expected normal after facet");
+            }
+            stream >> current_normal[0] >> current_normal[1] >> current_normal[2];
+            normals.push_back(current_normal);
+        } else if (token == "vertex") {
+            std::array<double, 3> vertex{};
+            stream >> vertex[0] >> vertex[1] >> vertex[2];
+            vertices.push_back(vertex);
+        }
+    }
+
+    if (vertices.empty() || vertices.size() % 3 != 0 || normals.size() * 3 != vertices.size()) {
+        throw std::runtime_error("Malformed ASCII STL: inconsistent triangle data");
+    }
+
+    return mesh_from_raw_faces(vertices, normals);
+}
+
+}  // namespace
+
+TriangleMesh load_stl(const std::string& path) {
+    std::ifstream file(path, std::ios::binary);
+    if (!file) {
+        throw std::runtime_error("Failed to open STL file: " + path);
+    }
+    const std::vector<char> buffer((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+    if (buffer.size() < 84) {
+        throw std::runtime_error("STL file is too small: " + path);
+    }
+
+    if (!looks_like_ascii(buffer)) {
+        return load_binary_stl(buffer);
+    }
+
+    try {
+        return load_ascii_stl(buffer);
+    } catch (const std::exception&) {
+        return load_binary_stl(buffer);
+    }
+}
+
+void write_binary_stl(const TriangleMesh& mesh, const std::string& path) {
+    std::ofstream file(path, std::ios::binary);
+    if (!file) {
+        throw std::runtime_error("Failed to open output STL file: " + path);
+    }
+
+    char header[80] = {};
+    std::snprintf(header, sizeof(header), "Generated by S4 mesh processor");
+    file.write(header, sizeof(header));
+
+    const std::uint32_t triangle_count = static_cast<std::uint32_t>(mesh.faces.size());
+    file.write(reinterpret_cast<const char*>(&triangle_count), sizeof(triangle_count));
+
+    for (std::size_t i = 0; i < mesh.faces.size(); ++i) {
+        const auto& face = mesh.faces[i];
+        const auto& normal = (i < mesh.face_normals.size()) ? mesh.face_normals[i] : std::array<double, 3>{0.0, 0.0, 1.0};
+        const auto write_float = [&file](double value) {
+            const float f = static_cast<float>(value);
+            file.write(reinterpret_cast<const char*>(&f), sizeof(float));
+        };
+
+        write_float(normal[0]);
+        write_float(normal[1]);
+        write_float(normal[2]);
+
+        for (int v = 0; v < 3; ++v) {
+            const auto& vertex = mesh.vertices[face[v]];
+            write_float(vertex[0]);
+            write_float(vertex[1]);
+            write_float(vertex[2]);
+        }
+
+        const std::uint16_t attribute_byte_count = 0;
+        file.write(reinterpret_cast<const char*>(&attribute_byte_count), sizeof(attribute_byte_count));
+    }
+}
+
+void write_colored_ply(const TriangleMesh& mesh,
+                       const std::vector<double>& face_values,
+                       const std::string& path) {
+    if (mesh.faces.size() != face_values.size()) {
+        throw std::runtime_error("Face values do not match mesh triangle count");
+    }
+
+    std::vector<std::array<double, 3>> vertex_colors(mesh.vertices.size(), {0.6, 0.6, 0.6});
+    std::vector<int> contributions(mesh.vertices.size(), 0);
+
+    double min_value = std::numeric_limits<double>::infinity();
+    double max_value = -std::numeric_limits<double>::infinity();
+    for (double value : face_values) {
+        if (std::isfinite(value)) {
+            min_value = std::min(min_value, value);
+            max_value = std::max(max_value, value);
+        }
+    }
+    if (!std::isfinite(min_value) || !std::isfinite(max_value) || min_value == max_value) {
+        min_value = -1.0;
+        max_value = 1.0;
+    }
+
+    auto value_to_color = [&](double value) {
+        if (!std::isfinite(value)) {
+            return std::array<double, 3>{0.5, 0.5, 0.5};
+        }
+        const double t = std::clamp((value - min_value) / (max_value - min_value), 0.0, 1.0);
+        return std::array<double, 3>{t, 0.2, 1.0 - t};
+    };
+
+    for (std::size_t face_index = 0; face_index < mesh.faces.size(); ++face_index) {
+        const auto color = value_to_color(face_values[face_index]);
+        for (int vertex : mesh.faces[face_index]) {
+            auto& target = vertex_colors[vertex];
+            target[0] += color[0];
+            target[1] += color[1];
+            target[2] += color[2];
+            contributions[vertex] += 1;
+        }
+    }
+
+    for (std::size_t i = 0; i < mesh.vertices.size(); ++i) {
+        if (contributions[i] > 0) {
+            vertex_colors[i][0] /= static_cast<double>(contributions[i] + 1);
+            vertex_colors[i][1] /= static_cast<double>(contributions[i] + 1);
+            vertex_colors[i][2] /= static_cast<double>(contributions[i] + 1);
+        }
+    }
+
+    std::ofstream file(path, std::ios::binary);
+    if (!file) {
+        throw std::runtime_error("Failed to open output PLY file: " + path);
+    }
+
+    file << "ply\n";
+    file << "format ascii 1.0\n";
+    file << "comment Generated by S4 mesh processor\n";
+    file << "element vertex " << mesh.vertices.size() << "\n";
+    file << "property float x\n";
+    file << "property float y\n";
+    file << "property float z\n";
+    file << "property uchar red\n";
+    file << "property uchar green\n";
+    file << "property uchar blue\n";
+    file << "element face " << mesh.faces.size() << "\n";
+    file << "property list uchar int vertex_indices\n";
+    file << "end_header\n";
+
+    for (std::size_t i = 0; i < mesh.vertices.size(); ++i) {
+        const auto& vertex = mesh.vertices[i];
+        const auto& color = vertex_colors[i];
+        const int r = static_cast<int>(std::clamp(color[0], 0.0, 1.0) * 255.0);
+        const int g = static_cast<int>(std::clamp(color[1], 0.0, 1.0) * 255.0);
+        const int b = static_cast<int>(std::clamp(color[2], 0.0, 1.0) * 255.0);
+        file << static_cast<float>(vertex[0]) << ' ' << static_cast<float>(vertex[1]) << ' '
+             << static_cast<float>(vertex[2]) << ' ' << r << ' ' << g << ' ' << b << "\n";
+    }
+
+    for (const auto& face : mesh.faces) {
+        file << "3 " << face[0] << ' ' << face[1] << ' ' << face[2] << "\n";
+    }
+}
+
+PathGradientInput build_path_gradient_input(const TriangleMesh& mesh,
+                                            double bottom_slice_fraction,
+                                            double overhang_angle_degrees,
+                                            int smoothing_iterations) {
+    PathGradientInput input;
+    const std::size_t face_count = mesh.faces.size();
+    input.cell_centers = mesh.face_centroids;
+    input.face_normals = mesh.face_normals;
+    input.point_neighbors.assign(face_count, {});
+    input.edge_neighbors.assign(face_count, {});
+    input.max_overhang_degrees = overhang_angle_degrees;
+    input.initial_rotation_field_smoothing = smoothing_iterations;
+    input.set_initial_rotation_to_zero = false;
+
+    if (face_count == 0) {
+        return input;
+    }
+
+    std::vector<std::vector<int>> vertex_to_faces(mesh.vertices.size());
+    for (std::size_t face_index = 0; face_index < face_count; ++face_index) {
+        for (int vertex : mesh.faces[face_index]) {
+            vertex_to_faces[vertex].push_back(static_cast<int>(face_index));
+        }
+    }
+
+    for (std::size_t face_index = 0; face_index < face_count; ++face_index) {
+        std::vector<int> neighbours;
+        const auto& face = mesh.faces[face_index];
+        for (int vertex : face) {
+            const auto& adjacent = vertex_to_faces[vertex];
+            neighbours.insert(neighbours.end(), adjacent.begin(), adjacent.end());
+        }
+        std::sort(neighbours.begin(), neighbours.end());
+        neighbours.erase(std::unique(neighbours.begin(), neighbours.end()), neighbours.end());
+        neighbours.erase(std::remove(neighbours.begin(), neighbours.end(), static_cast<int>(face_index)),
+                         neighbours.end());
+        input.point_neighbors[face_index] = std::move(neighbours);
+    }
+
+    std::unordered_map<std::uint64_t, std::vector<int>> edge_map;
+    edge_map.reserve(face_count * 3);
+    auto make_edge_key = [](int a, int b) {
+        const std::uint64_t min_v = static_cast<std::uint64_t>(std::min(a, b));
+        const std::uint64_t max_v = static_cast<std::uint64_t>(std::max(a, b));
+        return (min_v << 32) | max_v;
+    };
+
+    for (std::size_t face_index = 0; face_index < face_count; ++face_index) {
+        const auto& face = mesh.faces[face_index];
+        for (int e = 0; e < 3; ++e) {
+            const int a = face[e];
+            const int b = face[(e + 1) % 3];
+            edge_map[make_edge_key(a, b)].push_back(static_cast<int>(face_index));
+        }
+    }
+
+    for (const auto& [_, faces] : edge_map) {
+        if (faces.size() < 2) {
+            continue;
+        }
+        for (int f : faces) {
+            auto& list = input.edge_neighbors[f];
+            list.insert(list.end(), faces.begin(), faces.end());
+        }
+    }
+
+    for (auto& neighbours : input.edge_neighbors) {
+        std::sort(neighbours.begin(), neighbours.end());
+        neighbours.erase(std::unique(neighbours.begin(), neighbours.end()), neighbours.end());
+    }
+
+    double min_z = std::numeric_limits<double>::infinity();
+    double max_z = -std::numeric_limits<double>::infinity();
+    for (const auto& centroid : mesh.face_centroids) {
+        min_z = std::min(min_z, centroid[2]);
+        max_z = std::max(max_z, centroid[2]);
+    }
+    const double range_z = std::max(max_z - min_z, 1e-6);
+    const double threshold = min_z + range_z * bottom_slice_fraction;
+
+    for (std::size_t face_index = 0; face_index < face_count; ++face_index) {
+        if (mesh.face_centroids[face_index][2] <= threshold) {
+            input.bottom_cells.push_back(static_cast<int>(face_index));
+        }
+    }
+
+    if (input.bottom_cells.empty()) {
+        const auto it = std::min_element(mesh.face_centroids.begin(), mesh.face_centroids.end(),
+                                         [](const auto& a, const auto& b) { return a[2] < b[2]; });
+        if (it != mesh.face_centroids.end()) {
+            const int index = static_cast<int>(std::distance(mesh.face_centroids.begin(), it));
+            input.bottom_cells.push_back(index);
+        }
+    }
+
+    return input;
+}
+
+}  // namespace s4
+

--- a/cpp/stl_mesh.hpp
+++ b/cpp/stl_mesh.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <array>
+#include <string>
+#include <vector>
+
+#include "rotation_optimizer.hpp"
+
+namespace s4 {
+
+struct TriangleMesh {
+    std::vector<std::array<double, 3>> vertices;
+    std::vector<std::array<int, 3>> faces;
+    std::vector<std::array<double, 3>> face_normals;
+    std::vector<std::array<double, 3>> face_centroids;
+};
+
+TriangleMesh load_stl(const std::string& path);
+void write_binary_stl(const TriangleMesh& mesh, const std::string& path);
+void write_colored_ply(const TriangleMesh& mesh,
+                       const std::vector<double>& face_values,
+                       const std::string& path);
+
+PathGradientInput build_path_gradient_input(const TriangleMesh& mesh,
+                                            double bottom_slice_fraction = 0.02,
+                                            double overhang_angle_degrees = 30.0,
+                                            int smoothing_iterations = 2);
+
+}  // namespace s4
+


### PR DESCRIPTION
## Summary
- add STL loading, writing and PLY visualisation helpers for gradient inspection
- introduce a mesh_processor CLI that runs the path-length gradient solver on arbitrary STL meshes
- enable multithreaded smoothing in the rotation optimizer and update the README/build instructions

## Testing
- `g++ -std=c++17 -O3 -pthread cpp/mesh_processor.cpp cpp/stl_mesh.cpp cpp/rotation_optimizer.cpp -o mesh_processor`
- `./mesh_processor input_models/dino.stl output_models/dino_processed.stl output_models/dino_gradient.ply`


------
https://chatgpt.com/codex/tasks/task_e_68e57466b9dc832284cbbddf5d42c068